### PR TITLE
Font is cached by FontsMap

### DIFF
--- a/nodezator/fontsman/cache.py
+++ b/nodezator/fontsman/cache.py
@@ -125,7 +125,7 @@ def get_font(font_path, desired_height):
         """
         sizes = [desired, attempted]
 
-        if True in list(map(lambda s: s < 0 or s >= 65536, sizes)):
+        if any(map(lambda s: s < 0 or s >= 65536, sizes)):
 
             raise UnattainableFontHeight(font_path, desired_height)
 

--- a/nodezator/fontsman/cache.py
+++ b/nodezator/fontsman/cache.py
@@ -136,7 +136,7 @@ def get_font(font_path, desired_height):
     ### for the font size (here we use the desired height)
     ### and the actual height of a produced surface
 
-    raise_if_unreachable(desired_height, desired_height)
+    raise_if_unattainable(desired_height, desired_height, font_path)
 
     font = Font(font_path, desired_height)
     _, surf_height = font.size(" ")
@@ -164,7 +164,7 @@ def get_font(font_path, desired_height):
         ### surface of an arbitrary character (space) when
         ### rendered
 
-        raise_if_unreachable(desired_height, size)
+        raise_if_unattainable(desired_height, size, font_path)
 
         font = Font(font_path, size)
         _, surf_height = font.size(" ")
@@ -217,11 +217,12 @@ def get_font(font_path, desired_height):
     ### finally return the chosen font
     return chosen_font
 
-def raise_if_unreachable(desired, attempted):
+
+def raise_if_unattainable(desired_height, attempted_size, font_path):
     """Detect when technical limitations of font interpolation
     will prevent creation of certain font sizes.
     """
-    sizes = [desired, attempted]
+    sizes = [desired_height, attempted_size]
 
     if any(map(lambda s: s < 0 or s >= 65536, sizes)):
 

--- a/nodezator/fontsman/cache.py
+++ b/nodezator/fontsman/cache.py
@@ -119,16 +119,6 @@ def get_font(font_path, desired_height):
     surpass the desired height, that is, the font with
     surfaces of height 35.
     """
-    def raise_if_unreachable(desired, attempted):
-        """Detect when technical limitations of font interpolation
-        will prevent creation of certain font sizes.
-        """
-        sizes = [desired, attempted]
-
-        if any(map(lambda s: s < 0 or s >= 65536, sizes)):
-
-            raise UnattainableFontHeight(font_path, desired_height)
-
     ### create a set to keep track of the attempted sizes
     attempted_sizes = set()
 
@@ -226,3 +216,13 @@ def get_font(font_path, desired_height):
 
     ### finally return the chosen font
     return chosen_font
+
+def raise_if_unreachable(desired, attempted):
+    """Detect when technical limitations of font interpolation
+    will prevent creation of certain font sizes.
+    """
+    sizes = [desired, attempted]
+
+    if any(map(lambda s: s < 0 or s >= 65536, sizes)):
+
+        raise UnattainableFontHeight(font_path, desired_height)

--- a/nodezator/fontsman/test_cache.py
+++ b/nodezator/fontsman/test_cache.py
@@ -1,0 +1,79 @@
+from unittest import TestCase
+
+import pygame
+
+from .cache import get_font, FontsDatabase, FontsMap
+from .constants import NOTO_SANS_MONO_MEDIUM_FONT_PATH, NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
+from .exception import UnattainableFontHeight
+
+
+class TestFontsDatabase(TestCase):
+    def setUp(self) -> None:
+        pygame.font.init()
+
+    def test_get_font(self):
+        path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
+        name = 'Noto Sans Mono'
+        height = NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
+
+        font = get_font(path, height)
+
+        self.assertIs(type(font), pygame.font.Font)
+        self.assertIs(font.get_height(), height)
+        self.assertEqual(font.name, name)
+
+    def test_get_font_too_large_raises(self):
+        path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
+        height = 65536
+
+        with self.assertRaises(UnattainableFontHeight):
+            get_font(path, height)
+
+    def test_get_font_too_small_raises(self):
+        path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
+        height = 1
+
+        with self.assertRaises(UnattainableFontHeight):
+            get_font(path, height)
+
+    def test_fonts_db_returns(self):
+        db = FontsDatabase()
+        path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
+        name = 'Noto Sans Mono'
+        height = NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
+
+        font = db[path][height]
+
+        self.assertIs(type(font), pygame.font.Font)
+        self.assertIs(font.get_height(), height)
+        self.assertEqual(font.name, name)
+
+    def test_fonts_map_stores(self):
+        path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
+        height1 = NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
+        height2 = height1 + 2
+
+        m = FontsMap(path)
+
+        font1_get1 = m[height1]
+        font1_get2 = m[height1]
+
+        self.assertIs(font1_get1, font1_get2)
+
+        font2_get1 = m[height2]
+        font2_get2 = m[height2]
+        self.assertIs(font2_get1, font2_get2)
+
+    def test_fonts_database_stores(self):
+        db = FontsDatabase()
+        path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
+        height = NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
+
+        font1 = db[path][height]
+
+        self.assertIs(len(db), 1)
+
+        font2 = db[path][height]
+
+        self.assertIs(font1, font2)
+        self.assertIs(len(db), 1)

--- a/nodezator/fontsman/test_cache.py
+++ b/nodezator/fontsman/test_cache.py
@@ -17,7 +17,7 @@ class TestFontsDatabase(TestCase):
 
         font = get_font(path, height)
 
-        self.assertEqual(type(font), pygame.font.Font)
+        self.assertIsInstance(font, pygame.font.Font)
 
     def test_get_font_too_large_raises(self):
         path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
@@ -40,7 +40,7 @@ class TestFontsDatabase(TestCase):
 
         font = db[path][height]
 
-        self.assertEqual(type(font), pygame.font.Font)
+        self.assertIsInstance(font, pygame.font.Font)
 
     def test_fonts_map_stores(self):
         path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
@@ -52,11 +52,11 @@ class TestFontsDatabase(TestCase):
         font1_get1 = m[height1]
         font1_get2 = m[height1]
 
-        self.assertEqual(font1_get1, font1_get2)
+        self.assertIs(font1_get1, font1_get2)
 
         font2_get1 = m[height2]
         font2_get2 = m[height2]
-        self.assertEqual(font2_get1, font2_get2)
+        self.assertIs(font2_get1, font2_get2)
 
     def test_fonts_database_stores(self):
         db = FontsDatabase()
@@ -69,5 +69,5 @@ class TestFontsDatabase(TestCase):
 
         font2 = db[path][height]
 
-        self.assertEqual(font1, font2)
+        self.assertIs(font1, font2)
         self.assertEqual(len(db), 1)

--- a/nodezator/fontsman/test_cache.py
+++ b/nodezator/fontsman/test_cache.py
@@ -13,14 +13,11 @@ class TestFontsDatabase(TestCase):
 
     def test_get_font(self):
         path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
-        name = 'Noto Sans Mono'
         height = NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
 
         font = get_font(path, height)
 
-        self.assertIs(type(font), pygame.font.Font)
-        self.assertIs(font.get_height(), height)
-        self.assertEqual(font.name, name)
+        self.assertEqual(type(font), pygame.font.Font)
 
     def test_get_font_too_large_raises(self):
         path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
@@ -39,14 +36,11 @@ class TestFontsDatabase(TestCase):
     def test_fonts_db_returns(self):
         db = FontsDatabase()
         path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
-        name = 'Noto Sans Mono'
         height = NOTO_SANS_MONO_MEDIUM_FONT_HEIGHT
 
         font = db[path][height]
 
-        self.assertIs(type(font), pygame.font.Font)
-        self.assertIs(font.get_height(), height)
-        self.assertEqual(font.name, name)
+        self.assertEqual(type(font), pygame.font.Font)
 
     def test_fonts_map_stores(self):
         path = NOTO_SANS_MONO_MEDIUM_FONT_PATH
@@ -58,11 +52,11 @@ class TestFontsDatabase(TestCase):
         font1_get1 = m[height1]
         font1_get2 = m[height1]
 
-        self.assertIs(font1_get1, font1_get2)
+        self.assertEqual(font1_get1, font1_get2)
 
         font2_get1 = m[height2]
         font2_get2 = m[height2]
-        self.assertIs(font2_get1, font2_get2)
+        self.assertEqual(font2_get1, font2_get2)
 
     def test_fonts_database_stores(self):
         db = FontsDatabase()
@@ -71,9 +65,9 @@ class TestFontsDatabase(TestCase):
 
         font1 = db[path][height]
 
-        self.assertIs(len(db), 1)
+        self.assertEqual(len(db), 1)
 
         font2 = db[path][height]
 
-        self.assertIs(font1, font2)
-        self.assertIs(len(db), 1)
+        self.assertEqual(font1, font2)
+        self.assertEqual(len(db), 1)


### PR DESCRIPTION
Issue: #50 

- adds 'set' for font inside FontsMap dict, helper of FontsDatabase
- avoids infinite loop and NULL pointer exception for low and hight heights, respectively, by preventing out-of-bounds height instantiation attempts

Testing

- added integration test
- ran in the app. launches to title-screen, and loads small NDZ file, instantaneously. Previously would take ~1-3 seconds on M1 Macbook Pro.